### PR TITLE
A few improvements in memory usage and generation

### DIFF
--- a/accelerate_config.yaml
+++ b/accelerate_config.yaml
@@ -6,7 +6,7 @@ machine_rank: 0
 main_process_ip: 127.0.0.1
 main_process_port: 12345
 main_training_function: main
-mixed_precision: 'no'
+mixed_precision: 'fp16'
 num_machines: 1
 num_processes: 2
 use_cpu: false

--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,8 @@ llm_client:
 PPO_updater:
   lr: 2e-6
   minibatch_size: 4 
+  epochs: 1
+  gradient_accumulation_steps: 4
   clip_eps: .2 
   entropy_loss_coef: 0.01
   value_loss_coef: .5
@@ -39,7 +41,7 @@ lamorel_args:
     generation_args:
       max_new_tokens: 128
       num_return_sequences: 2
-      do_sample: true
+      num_beams: 3
 rl_script_args:
   path: ???
   seed: 41


### PR DESCRIPTION
- Use beam search instead of sampling in LLM agent.
- Using `mixed_precision`  for the computations in the models.
- Add `gradient_accumulation_step` to `PPOUpdater` to account for a thing that I speculate was a bug.
- Moving model output from GPU to CPU instead of moving buffer items back to GPU in `PPOUpdater` to reduce GPU usage.